### PR TITLE
chore: remove netlify plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,0 @@
-[[plugins]]
-package = 'netlify-plugin-environment-variables'

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "husky": "^7.0.0",
         "lint-staged": "^12.1.2",
         "msw": "^0.36.3",
-        "netlify-plugin-environment-variables": "^1.0.3",
         "tailwindcss": "^3.0.5",
         "vue-template-compiler": "^2.6.11"
       }
@@ -12788,12 +12787,6 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/netlify-plugin-environment-variables": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/netlify-plugin-environment-variables/-/netlify-plugin-environment-variables-1.0.3.tgz",
-      "integrity": "sha512-SGfx68Ci+pcenikCCy9Hn3FQZ9H9P17qHrKhqEu8nof4+PPHL9NuEdQyKNGpaG20Pd9pBpP9pqgkIl8FkU9iyg==",
-      "dev": true
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -28854,12 +28847,6 @@
     },
     "neo-async": {
       "version": "2.6.2",
-      "dev": true
-    },
-    "netlify-plugin-environment-variables": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/netlify-plugin-environment-variables/-/netlify-plugin-environment-variables-1.0.3.tgz",
-      "integrity": "sha512-SGfx68Ci+pcenikCCy9Hn3FQZ9H9P17qHrKhqEu8nof4+PPHL9NuEdQyKNGpaG20Pd9pBpP9pqgkIl8FkU9iyg==",
       "dev": true
     },
     "nice-try": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "husky": "^7.0.0",
     "lint-staged": "^12.1.2",
     "msw": "^0.36.3",
-    "netlify-plugin-environment-variables": "^1.0.3",
     "tailwindcss": "^3.0.5",
     "vue-template-compiler": "^2.6.11"
   },


### PR DESCRIPTION
#### Description

This project is now using [environment variables plugin](https://www.npmjs.com/package/netlify-plugin-contextual-env/v/0.3.0) via Netlify's in-app [plugins directory](https://app.netlify.com/plugins) and no need to install the npm package for that plugin

#### Changes

- Remove netlify plugin package

#### Evidence

Title: Remove netlify plugin
Project: Portal Jabar
Participants: @bangunbagustapa @yoslie @adzharamrullah @Ibwedagama @naufalihsank @maulanayuseph @maruf12 