### PR TITLE
feat: display tags on agenda preview

### DIFF
--- a/src/components/Agenda/AgendaPreview.vue
+++ b/src/components/Agenda/AgendaPreview.vue
@@ -176,7 +176,6 @@
             <h2 class="text-xs text-blue-gray-200">
               Tags
             </h2>
-            <!-- TODO: Add tags pills -->
             <div class="min-w-0 flex gap-2 flex-wrap items-center">
               <span
                 v-for="tag in event.tags"

--- a/src/components/Agenda/AgendaPreview.vue
+++ b/src/components/Agenda/AgendaPreview.vue
@@ -159,6 +159,7 @@
         </div>
 
         <div
+          v-if="hasTags"
           ref="agenda-preview-tags"
           class="flex gap-2 col-span-2"
         >
@@ -176,6 +177,15 @@
               Tags
             </h2>
             <!-- TODO: Add tags pills -->
+            <div class="min-w-0 flex gap-2 flex-wrap items-center">
+              <span
+                v-for="tag in event.tags"
+                :key="tag.id"
+                class="px-[10px] py-[6px] rounded-full bg-gray-200 text-gray-700 text-sm"
+              >
+                {{ tag.tag_name }}
+              </span>
+            </div>
           </div>
         </div>
       </section>
@@ -215,6 +225,9 @@ export default {
     },
     date() {
       return this.event?.date ? formatDate(this.event.date, 'EEEE, dd MMM yyyy') : '-';
+    },
+    hasTags() {
+      return this.event?.tags && !!this.event?.tags.length;
     },
   },
 };


### PR DESCRIPTION
#### Related
- [S28A3 - Pop up Preview Agenda
](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/recEbd0mTSlsCe6hF?blocks=hide)

#### Changes
- add tags on agenda preview

#### Preview
![Screen Shot 2022-01-17 at 14 24 10](https://user-images.githubusercontent.com/33661143/149725387-ee346776-4f84-42ac-9663-5995218b6901.png)

### Evidence
title: feat display tags on agenda preview
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @yoslie @bangunbagustapa 
