### PR TITLE
feat: filter news by status

### DIFF
--- a/src/components/NewsInformation/News/index.vue
+++ b/src/components/NewsInformation/News/index.vue
@@ -5,6 +5,7 @@
       <NewsTabBar
         :tabs="tabs"
         :current-tab.sync="currentTab"
+        @update:currentTab="filterNewsByStatus"
       />
       <section class="w-full bg-white py-6 px-3">
         <div class="w-full flex justify-between mb-5 items-center">
@@ -105,6 +106,7 @@ export default {
         end_date: formatDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0), 'yyyy/MM/dd'), // last date of today's month
         per_page: 10,
         page: 1,
+        status: null,
       },
     };
   },
@@ -175,6 +177,16 @@ export default {
           message: 'Gagal mendapatkan data Total Berita, silakan coba beberapa saat lagi',
         });
       }
+    },
+
+    filterNewsByStatus(status) {
+      if (status === 'ALL') {
+        this.setParams({ status: null });
+      } else {
+        this.setParams({ status });
+      }
+
+      this.fetchNews();
     },
 
     /**


### PR DESCRIPTION
#### Related
- [S29A6 - Tab Status Berita](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/rec9K2FkTuqWyIDvx?blocks=hide)

#### Changes
- add an event listener on `NewsTabBar`
- update params based on tab status
- fetch news on tab change

#### Preview

https://user-images.githubusercontent.com/33661143/153552554-48f44b99-acff-45fc-8ada-7babe6c4dae9.mov


### Evidence
title: feat filter news by status
project: Portal Jabar
participants: @Ibwedagama 
