### PR TITLE
fix: fix news date param format

### DIFF
--- a/src/components/NewsInformation/News/NewsMonthFilter.vue
+++ b/src/components/NewsInformation/News/NewsMonthFilter.vue
@@ -43,11 +43,11 @@ export default {
   computed: {
     firstDate() {
       const firstDate = new Date(this.date.getFullYear(), this.date.getMonth(), 1);
-      return formatDate(firstDate, 'yyyy/MM/dd');
+      return formatDate(firstDate, 'yyyy-MM-dd');
     },
     lastDate() {
       const lastDate = new Date(this.date.getFullYear(), this.date.getMonth() + 1, 0);
-      return formatDate(lastDate, 'yyyy/MM/dd');
+      return formatDate(lastDate, 'yyyy-MM-dd');
     },
     month() {
       return formatDate(this.date, 'MMMM');

--- a/src/components/NewsInformation/News/index.vue
+++ b/src/components/NewsInformation/News/index.vue
@@ -154,8 +154,8 @@ export default {
         per_page: 10,
       },
       params: {
-        start_date: formatDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1), 'yyyy/MM/dd'), // first date of today's month
-        end_date: formatDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0), 'yyyy/MM/dd'), // last date of today's month
+        start_date: formatDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1), 'yyyy-MM-dd'), // first date of today's month
+        end_date: formatDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0), 'yyyy-MM-dd'), // last date of today's month
         per_page: 10,
         page: 1,
         status: null,


### PR DESCRIPTION
#### Overview
- as described by the title

#### Changes
- fix `start_date` and `last_date` params format on `News/Index.vue`
- fix `firstDate` and `lastDate` value format on `NewsMonthFilter` component

### Evidence
title: fix news date param format
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @bangunbagustapa @yoslie 