### PR TITLE
feat: inject news prefix on submit and save news

### DIFF
--- a/src/pages/News/CreateEditNews.vue
+++ b/src/pages/News/CreateEditNews.vue
@@ -466,6 +466,7 @@ export default {
           images_upload_handler: this.onContentImageUpload,
           image_caption: true,
         },
+        // 'initial-value': '<span><strong>PORTALJABAR, BANDUNG  - </strong></span>',
       }),
       loading: false,
       progress: 0,
@@ -594,6 +595,40 @@ export default {
       container.insertAdjacentHTML('beforeend', html);
 
       return container.textContent;
+    },
+    insertNewsPrefix(html) {
+      try {
+        const container = document.createElement('div');
+        container.innerHTML = html;
+
+        const paragraphs = container.querySelectorAll('p');
+
+        /**
+       * Filter only paragraph that only contain a text,
+       * not a break or new line element,
+       * and doesn't have image as it's children.
+       */
+        const textOnlyParagraphs = Array.from(paragraphs)
+          .filter((item) => item.innerText.trim() !== '' && !item.contains(item.querySelector('img')));
+
+        if (textOnlyParagraphs.length) {
+          const firstParagraph = textOnlyParagraphs[0];
+
+          const selectedLocation = this.locationOptions
+            .find((item) => item.value === this.form.areaId);
+
+          const prefixText = `<span><strong>PORTALJABAR, ${selectedLocation.label} - </strong></span>`;
+
+          // Insert prefix before the first paragraph's text content
+          firstParagraph.insertAdjacentHTML('afterbegin', prefixText);
+
+          return container.innerHTML;
+        }
+
+        return html;
+      } catch (error) {
+        return html;
+      }
     },
     isEmpty(data) {
       return data === '' || data === null;
@@ -861,7 +896,7 @@ export default {
         title,
         excerpt: this.sanitizeHTML(content).slice(0, 160),
         image,
-        content,
+        content: this.isEditMode ? content : this.insertNewsPrefix(content),
         start_date: this.selectedDate ? formatDate(this.selectedDate, 'yyyy-MM-dd') : null,
         end_date: endDate ? formatDate(endDate, 'yyyy-MM-dd') : null,
         category,

--- a/src/pages/News/CreateEditNews.vue
+++ b/src/pages/News/CreateEditNews.vue
@@ -466,7 +466,6 @@ export default {
           images_upload_handler: this.onContentImageUpload,
           image_caption: true,
         },
-        // 'initial-value': '<span><strong>PORTALJABAR, BANDUNG  - </strong></span>',
       }),
       loading: false,
       progress: 0,


### PR DESCRIPTION
#### Related
- [T95 - Preview - Prefix Berita - FE](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/recNoI1RH8mPTXYdf?blocks=hide)

#### Changes
- add method to inject news prefix
- mutate content data on submit and save

#### Preview
![Screen Shot 2022-02-18 at 14 33 25](https://user-images.githubusercontent.com/33661143/154638191-ba70096b-c76a-44c9-8891-45cdffe7c39a.png)

### Evidence
title: feat inject news prefix on submit
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @bangunbagustapa @doohanas 