### PR TITLE
feat: delete news

### DIFF
--- a/src/components/NewsInformation/News/NewsTableAction.vue
+++ b/src/components/NewsInformation/News/NewsTableAction.vue
@@ -104,7 +104,7 @@ export default {
         PUBLISHED: ['preview', 'archive'],
         DRAFT: ['preview', 'edit', 'delete'],
         REVIEW: ['preview', 'publish', 'edit'],
-        ARCHIVED: ['preview', 'delete'],
+        ARCHIVED: ['preview'],
       }),
     };
   },

--- a/src/components/NewsInformation/News/NewsTableAction.vue
+++ b/src/components/NewsInformation/News/NewsTableAction.vue
@@ -34,7 +34,7 @@
             Pratinjau
           </a>
         </li>
-        <!-- TODO: Add action on publish clicked -->
+        <!-- Publish Action-->
         <li v-if="shouldShowAction('publish')">
           <button
             class="font-lato text-sm leading-4 text-gray-800"
@@ -43,7 +43,7 @@
             Terbitkan
           </button>
         </li>
-        <!-- TODO: Add action on edit clicked -->
+        <!-- Edit Action -->
         <li v-if="shouldShowAction('edit')">
           <router-link
             to="#"
@@ -52,7 +52,7 @@
             Ubah
           </router-link>
         </li>
-        <!-- TODO: Add action on archive clicked -->
+        <!-- Archive Action -->
         <li v-if="shouldShowAction('archive')">
           <button
             class="font-lato text-sm leading-4 text-gray-800"
@@ -61,7 +61,7 @@
             Arsipkan
           </button>
         </li>
-        <!-- TODO: Add action on delete clicked -->
+        <!-- Delete Action -->
         <li v-if="shouldShowAction('delete')">
           <button
             class="font-lato text-sm leading-4 text-gray-800"

--- a/src/components/NewsInformation/News/index.vue
+++ b/src/components/NewsInformation/News/index.vue
@@ -34,6 +34,7 @@
           @update:pagination="onUpdatePagination($event)"
           @publish="setupPromptDetail('publish', $event)"
           @archive="setupPromptDetail('archive', $event)"
+          @delete="setupPromptDetail('delete', $event)"
         />
       </section>
     </section>
@@ -263,6 +264,21 @@ export default {
       }
     },
 
+    async deleteNews(id) {
+      try {
+        this.promptDetail.loading = true;
+
+        await newsRepository.deleteNews(id);
+
+        this.$toast({ type: 'success', message: 'Berita telah berhasil dihapus' });
+      } catch (error) {
+        this.$toast({ type: 'error', message: 'Mohon maaf, gagal menghapus berita!' });
+      } finally {
+        this.closeActionPrompt();
+        this.fetchNews();
+      }
+    },
+
     filterNewsByStatus(status) {
       if (status === 'ALL') {
         this.setParams({ status: null });
@@ -346,6 +362,19 @@ export default {
           subtitle: 'Apakah Anda yakin akan mengarsipkan berita ini?',
           buttonLabel: 'Ya, arsipkan berita',
           buttonClick: () => this.archiveNews(news.id),
+          newsTitle: news.title,
+          newsId: news.id,
+          loading: false,
+        };
+      }
+
+      if (action === 'delete') {
+        this.promptDetail = {
+          action: 'delete',
+          title: 'Hapus Berita',
+          subtitle: 'Apakah Anda yakin akan menghapus berita ini?',
+          buttonLabel: 'Ya, saya yakin',
+          buttonClick: () => this.deleteNews(news.id),
           newsTitle: news.title,
           newsId: news.id,
           loading: false,

--- a/src/repositories/newsRepository.js
+++ b/src/repositories/newsRepository.js
@@ -73,6 +73,12 @@ export default {
     return Repository.post(`${resource}`, body);
   },
 
+  /**
+   * Delete event by id
+   * @param {string, number} id
+   *
+   * @returns {Promise}
+   */
   deleteNews(id = null) {
     return Repository.delete(`${resource}/${id}`);
   },

--- a/src/repositories/newsRepository.js
+++ b/src/repositories/newsRepository.js
@@ -72,4 +72,8 @@ export default {
   createNews(body) {
     return Repository.post(`${resource}`, body);
   },
+
+  deleteNews(id = null) {
+    return Repository.delete(`${resource}/${id}`);
+  },
 };


### PR DESCRIPTION
#### Related
- [S29A7 - Delete Berita](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/recWJb5vHMv7c2zr7?blocks=hide)

#### Changes
- add `deleteNews` method on `newsRepository`
- add delete functionality on `News` page

#### Preview

https://user-images.githubusercontent.com/33661143/156302919-b7fec747-b275-4d88-b077-bb57923485cd.mov

#### Note
- the delete functionality is still not working right now because the `DELETE` API route is still in development
- it will be fixed asap

### Evidence
title: feat delete news
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @maruf12 @yoslie 
