### PR TITLE
refactor: change order of news status tab

### DIFF
--- a/src/components/NewsInformation/News/index.vue
+++ b/src/components/NewsInformation/News/index.vue
@@ -139,12 +139,6 @@ export default {
           count: null,
         },
         {
-          key: 'PUBLISHED',
-          label: 'Diterbitkan',
-          icon: 'PublishIcon',
-          count: null,
-        },
-        {
           key: 'DRAFT',
           label: 'Tersimpan',
           icon: 'DraftIcon',
@@ -154,6 +148,12 @@ export default {
           key: 'REVIEW',
           label: 'Menunggu Review',
           icon: 'ReviewIcon',
+          count: null,
+        },
+        {
+          key: 'PUBLISHED',
+          label: 'Diterbitkan',
+          icon: 'PublishIcon',
           count: null,
         },
         {


### PR DESCRIPTION
#### Overview
- as described by the title

#### Preview
Before
<img width="1157" alt="Screen Shot 2022-03-10 at 13 46 19" src="https://user-images.githubusercontent.com/33661143/157597550-9167f262-addf-4855-8f4b-45f1420069e7.png">

After
<img width="1157" alt="Screen Shot 2022-03-10 at 13 46 34" src="https://user-images.githubusercontent.com/33661143/157597575-5d64dacf-c7b2-4ca4-8586-25b7d9e6d132.png">

### Evidence
title: change order of news status tab
project: Portal Jabar
participants: @Ibwedagama @bangunbagustapa @doohanas 
