### PR TITLE
fix(news): show prefix when previewing news

### DIFF
--- a/src/pages/News/CreateEditNews.vue
+++ b/src/pages/News/CreateEditNews.vue
@@ -579,6 +579,7 @@ export default {
         id: this.newsId,
         author: this.author,
         image: this.imagePreview,
+        content: this.isEditMode ? this.form.content : this.insertNewsPrefix(this.form.content),
       };
 
       return data;


### PR DESCRIPTION
### Related

- [T95 - Preview - Prefix Berita](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/recNoI1RH8mPTXYdf?blocks=hide)

### Preview

<img width="1413" alt="Screen Shot 2022-03-14 at 12 40 02" src="https://user-images.githubusercontent.com/55199533/158111845-c39d45f5-0131-48ae-8f65-586ea110488f.png">

### Evidence

Title: 
Project: Portal Jabar
Participants: @bangunbagustapa @Ibwedagama @doohanas 