### PR TITLE
improve: news preview

### DIFF
--- a/src/components/NewsInformation/News/NewsPreview.vue
+++ b/src/components/NewsInformation/News/NewsPreview.vue
@@ -115,7 +115,7 @@
           <!-- News Tags -->
           <div
             v-show="hasTags"
-            class="flex gap-4 items-center"
+            class="flex flex-wrap gap-4 items-center"
           >
             <span class="inline-flex items-center font-lato font-bold text-green-800 text-sm leading-6">
               Tags
@@ -484,9 +484,52 @@ body {
   overflow: auto !important;
 }
 
-.article__body h1, .article__body h2, .article__body h3, .article__body h4, .article__body h5, .article__body h6, .article__body p {
+.article__body h1,
+.article__body h2,
+.article__body h3,
+.article__body h4,
+.article__body h5,
+.article__body h6,
+.article__body p,
+.article__body strong {
   font-family: 'Lora';
   color: #424242 ;
+}
+
+.article__body h1 {
+  font-size: 5.8rem;
+  line-height: 8.8rem;
+  font-weight: 400;
+}
+
+.article__body h2 {
+  font-size: 4rem;
+  line-height: 6.5rem;
+  font-weight: 700;
+}
+
+.article__body h3 {
+  font-size: 3rem;
+  line-height: 4.9rem;
+  font-weight: 700;
+}
+
+.article__body h4 {
+  font-size: 2.3rem;
+  line-height: 3.75rem;
+  font-weight: 700;
+}
+
+.article__body h5 {
+  font-size: 1.75rem;
+  line-height: 2.8rem;
+  font-weight: 700;
+}
+
+.article__body h6 {
+  font-size: 1.3rem;
+  line-height: 2.1rem;
+  font-weight: 700;
 }
 
 .article__body p {
@@ -500,10 +543,20 @@ body {
   height: auto;
 }
 
+.article__body figure figcaption {
+  text-align: center;
+  font-size: 1rem;
+  line-height: 1.8rem;
+  color: #616161;
+}
+
 .article__body blockquote {
   border-left-width: 8px ;
   border-color: #E0E0E0;
   padding: 0 1.5rem;
+}
+
+.article__body blockquote p {
   font-family: 'Lora';
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/NewsInformation/News/NewsPreview.vue
+++ b/src/components/NewsInformation/News/NewsPreview.vue
@@ -36,20 +36,54 @@
         </div>
       </div>
       <div class="relative z-20 max-w-screen-xl w-full mx-auto mt-[42px] pb-16">
-        <h1 class="font-lora font-medium text-[34px] leading-[48px] text-white mb-6 max-w-3xl">
+        <!-- Title skeleton -->
+        <div
+          v-show="!title"
+          class="w-full h-[96px] flex flex-col gap-4 justify-center mb-6"
+        >
+          <div class="w-3/5 h-[28px] bg-gray-500 opacity-25 rounded-lg animate-pulse" />
+          <div class="w-2/5 h-[28px] bg-gray-500 opacity-25 rounded-lg animate-pulse" />
+        </div>
+        <!-- end of skeleton -->
+        <h1
+          v-show="title"
+          class="font-lora font-medium text-[34px] leading-[48px] text-white mb-6 max-w-3xl"
+        >
           {{ title }}
         </h1>
         <div class="flex gap-3 items-center mb-6">
           <p class="font-lato font-normal text-sm text-blue-gray-100 flex items-center">
             <CalendarIcon class="inline mr-[10px] w-4 h-4 fill-gray-200" />
-            {{ date }}
+            <!-- Date skeleton -->
+            <span
+              v-show="!date"
+              class="w-[132px] h-5 flex items-center"
+            >
+              <div class="w-full h-[14px] bg-gray-500 opacity-25 rounded-md animate-pulse " />
+            </span>
+            <!-- end of skeleton -->
+            <span v-show="date">{{ date }}</span>
           </p>
           <p class="font-normal text-sm text-blue-gray-100">
             |
           </p>
           <p class="font-lato font-normal text-sm text-blue-gray-100 flex items-center capitalize">
             <PenIcon class="inline mr-[10px] w-4 h-4 fill-gray-200" />
-            Penulis : {{ author }}
+            Penulis :
+            <!-- Author skeleton -->
+            <span
+              v-show="!author"
+              class="ml-3 w-[132px] h-5 flex items-center"
+            >
+              <div class="w-full h-[14px] bg-gray-500 opacity-25 rounded-md animate-pulse" />
+            </span>
+            <!-- end of skeleton -->
+            <span
+              v-show="author"
+              class="ml-3"
+            >
+              {{ author }}
+            </span>
           </p>
         </div>
         <div class="w-full flex justify-between">
@@ -107,8 +141,26 @@
     <section class="mt-12 mb-12">
       <div class="max-w-screen-xl w-full h-full mx-auto grid grid-cols-[60%_auto] gap-20">
         <div>
-          <!-- News Content -->
+          <!-- News content skeleton -->
+          <div
+            v-show="!content"
+            class="w-full min-h-screen"
+          >
+            <div
+              v-for="index in 3"
+              :key="index"
+              class="flex flex-col gap-5 mb-16"
+            >
+              <div class="w-12/12 h-[16px] bg-gray-200 rounded-md animate-pulse" />
+              <div class="w-11/12 h-[16px] bg-gray-200 rounded-md animate-pulse" />
+              <div class="w-9/12 h-[16px] bg-gray-200 rounded-md animate-pulse" />
+              <div class="w-11/12 h-[16px] bg-gray-200 rounded-md animate-pulse" />
+              <div class="w-8/12 h-[16px] bg-gray-200 rounded-md animate-pulse" />
+            </div>
+          </div>
+          <!-- end of skeleton -->
           <article
+            v-show="content"
             class="article__body min-h-screen"
             v-html="content"
           />
@@ -438,13 +490,15 @@ export default {
       return this.news?.image || null;
     },
     title() {
-      return this.news?.title || '-';
+      return this.news?.title || '';
     },
     date() {
-      return formatDate(this.news?.updated_at || new Date(), 'EEEE, dd LLLL yyyy');
+      return this.news?.updated_at
+        ? formatDate(this.news.updated_at, 'EEEE, dd LLLL yyyy')
+        : null;
     },
     author() {
-      return this.news?.author?.name || '-';
+      return this.news?.author?.name || '';
     },
     views() {
       return this.news?.views || 0;
@@ -453,7 +507,7 @@ export default {
       return this.news?.shared || 0;
     },
     content() {
-      return this.news?.content || null;
+      return this.news?.content || '';
     },
     tags() {
       return this.news?.tags || [];


### PR DESCRIPTION
#### Related
- [T96 - Skeleton Loader - Berita (CMS dan Web Publik) - FE](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/recZBedeWjb8aQfSc?blocks=hide)

#### Changes
- improve styling on news content (header, blockquote, image caption)
- add skeleton loader to news header and content

#### Preview
- **Skeleton Loader**

![ezgif-2-3269f4d76f](https://user-images.githubusercontent.com/33661143/158111906-36645859-ff96-479e-88fe-1cdce95a16a9.gif)

- **News Content**

![Portal-Jabar-Content-Management-System](https://user-images.githubusercontent.com/33661143/158112073-f45ba93b-8586-4bdd-85f1-1ad9ccfd2212.png)

### Evidence
title: improve news preview
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @bangunbagustapa @doohanas 

