### PR TITLE
chore(news): replace div tag to paragraph tag

### DIFF
--- a/src/pages/News/CreateEditNews.vue
+++ b/src/pages/News/CreateEditNews.vue
@@ -473,6 +473,7 @@ export default {
             outdent indent | link image media | fullscreen `,
           images_upload_handler: this.onContentImageUpload,
           image_caption: true,
+          invalid_elements: 'div',
         },
       }),
       loading: false,


### PR DESCRIPTION
### Overview

Change all `<div>` in editor content to be `<p>`.

### Evidence

Title: chore(news): replace div tag to paragraph tag
Project: Portal Jabar
Participants: @bangunbagustapa @adzharamrullah @Ibwedagama @doohanas 