### PR TITLE
style: fix active link styling on nested route

### DIFF
--- a/src/common/components/Sidebar.vue
+++ b/src/common/components/Sidebar.vue
@@ -35,14 +35,15 @@
       <router-link
         v-for="navigation in navigationMenu"
         :key="navigation.label"
-        v-slot="{ href, navigate, isExactActive }"
+        v-slot="{ href, navigate, isActive }"
         :to="navigation.link"
+        :exact="navigation.link === '/'"
         custom
       >
         <li
           class="w-full min-h-[50px] p-[15px] flex items-center rounded-lg font-lato
           font-bold text-sm text-white hover:bg-green-700 mb-2"
-          :class="{'bg-green-700' : isExactActive}"
+          :class="{'bg-green-700' : isActive}"
         >
           <a
             :href="href"
@@ -75,14 +76,14 @@
       class="mt-auto"
     >
       <router-link
-        v-slot="{ href, navigate, isExactActive }"
+        v-slot="{ href, navigate, isActive }"
         to="/pengaturan"
         custom
       >
         <li
           class="w-full min-h-[50px] p-[15px] flex items-center rounded-lg font-lato
           font-bold text-sm text-white hover:bg-green-700 mb-2"
-          :class="{'bg-green-700' : isExactActive}"
+          :class="{'bg-green-700' : isActive}"
         >
           <a
             :href="href"


### PR DESCRIPTION
### Related
- [T70 - Inconsistency sidebar menu - Agenda - FE](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/recpt9Y7cukloj9A4?blocks=hide)

### Changes
- add exact attribute on home route  ('/') `<router-link>`
- change `isExactActive` property to `isActive` so the nested route also become active link

 ### Preview
![ezgif-4-9ef91ad3de](https://user-images.githubusercontent.com/33661143/158327862-fc1a7d68-5536-4f4a-9c78-e23709785533.gif)


### Evidence
title: fix active link styling on nested route
project: Portal Jabar
participants: @Ibwedagama @maruf12 @bangunbagustapa @naufalihsank @doohanas 
