### PR TITLE
fix: status counter not updating data

### DIFF
--- a/src/components/NewsInformation/News/index.vue
+++ b/src/components/NewsInformation/News/index.vue
@@ -268,6 +268,7 @@ export default {
       } finally {
         this.closeActionPrompt();
         this.fetchNews();
+        this.fetchStatusCounter();
       }
     },
 
@@ -283,6 +284,7 @@ export default {
       } finally {
         this.closeActionPrompt();
         this.fetchNews();
+        this.fetchStatusCounter();
       }
     },
 
@@ -298,6 +300,7 @@ export default {
       } finally {
         this.closeActionPrompt();
         this.fetchNews();
+        this.fetchStatusCounter();
       }
     },
 


### PR DESCRIPTION
#### Overview
- fix news status counter not updating the data after users do some actions like publish, delete or archive the news

#### Changes
- fetch news status counter after updating news data

#### Preview

https://user-images.githubusercontent.com/33661143/159859778-0e1e3ada-b5c9-41c6-9121-083e7a10719c.mov

### Evidence
title: fix status counter not updating data
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @maruf12 @bangunbagustapa @naufalihsank @doohanas 
