### PR TITLE
refactor(password tooltip): move the tooltip into a seperate component

### DIFF
--- a/src/common/components/PasswordTooltip.vue
+++ b/src/common/components/PasswordTooltip.vue
@@ -1,0 +1,84 @@
+<template>
+  <Tooltip :show="show">
+    <div class="flex gap-2 mb-2">
+      <div
+        class="h-1 rounded-lg w-14"
+        :class="[lowBarClassName]"
+      />
+      <div
+        class="h-1 rounded-lg w-14"
+        :class="[mediumBarClassName]"
+      />
+      <div
+        class="h-1 rounded-lg w-14"
+        :class="[strongBarClassName]"
+      />
+    </div>
+    <p>Kata sandi Anda <span :class="passwordStrengthLabelClassName">{{ passwordStrength.label }}</span></p>
+  </Tooltip>
+</template>
+
+<script>
+import Tooltip from '@/common/components/Tooltip';
+
+export default {
+  name: 'PasswordTooltip',
+  components: {
+    Tooltip,
+  },
+  props: {
+    show: {
+      type: Boolean,
+      required: true,
+    },
+    passwordStrength: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    lowBarClassName() {
+      switch (this.passwordStrength.type) {
+        case 'low':
+          return 'bg-red-600';
+        case 'medium':
+          return 'bg-yellow-600';
+        case 'strong':
+          return 'bg-green-600';
+        default:
+          return 'bg-gray-600';
+      }
+    },
+    mediumBarClassName() {
+      switch (this.passwordStrength.type) {
+        case 'medium':
+          return 'bg-yellow-600';
+        case 'strong':
+          return 'bg-green-600';
+        default:
+          return 'bg-gray-600';
+      }
+    },
+    strongBarClassName() {
+      switch (this.passwordStrength.type) {
+        case 'strong':
+          return 'bg-green-600';
+        default:
+          return 'bg-gray-600';
+      }
+    },
+    passwordStrengthLabelClassName() {
+      switch (this.passwordStrength.type) {
+        case 'low':
+          return 'text-red-500';
+        case 'medium':
+          return 'text-yellow-500';
+        case 'strong':
+          return 'text-green-500';
+        default:
+          return '';
+      }
+    },
+  },
+};
+</script>

--- a/src/common/components/Tooltip.vue
+++ b/src/common/components/Tooltip.vue
@@ -1,0 +1,22 @@
+<template>
+  <div
+    v-show="show"
+    class="absolute mb-2"
+  >
+    <div class="bg-gray-900 p-3 top-0 left-0 rounded-lg text-white text-xs">
+      <slot />
+    </div>
+    <div class="absolute top-1 left-3 w-3 h-3 -mt-2 rotate-45 bg-gray-900" />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    show: {
+      type: Boolean,
+      required: true,
+    },
+  },
+};
+</script>

--- a/src/components/CreateAccount/Form/PasswordForm.vue
+++ b/src/components/CreateAccount/Form/PasswordForm.vue
@@ -15,12 +15,15 @@
       >
         <input
           id="password"
+          ref="password"
           :value="password"
           :type="passwordInputType['password']"
           placeholder="Masukkan kata sandi"
           class="text-sm placeholder:text-gray-600 p-2 w-full focus:outline-none focus-within:placeholder:text-gray-500"
           :class="[errors.password ? 'bg-red-50' : 'bg-gray-50 focus-within:bg-gray-50']"
-          @input="$emit('password', $event.target.value)"
+          @input="onInput"
+          @focus="openTooltip"
+          @blur="closeTooltip"
         >
         <div
           v-show="isPasswordIconVisible['password']"
@@ -40,30 +43,10 @@
         {{ errors.password }}
       </p>
     </div>
-    <!-- Tooltip -->
-    <div
-      v-show="!isEmpty(password)"
-      class="flex relative mb-2"
-    >
-      <div class="bg-gray-900 px-3 pt-3 pb-2 rounded-lg text-white text-xs">
-        <div class="grid grid-cols-3 gap-2 mb-2">
-          <div
-            class="h-1 rounded-lg"
-            :class="[lowBarClassName]"
-          />
-          <div
-            class="h-1 rounded-lg"
-            :class="[mediumBarClassName]"
-          />
-          <div
-            class="h-1 rounded-lg"
-            :class="[strongBarClassName]"
-          />
-        </div>
-        <p>Kata sandi Anda <span :class="passwordStrengthLabelClassName">{{ passwordStrength.label }}</span></p>
-      </div>
-      <div class="absolute top-1 left-3 w-3 h-3 -mt-2 rotate-45 bg-gray-900" />
-    </div>
+    <PasswordTooltip
+      :show="isTooltipOpen"
+      :password-strength="passwordStrength"
+    />
     <!-- Password confirmation input -->
     <div class="flex flex-col flex-grow gap-1 mb-4">
       <label
@@ -108,8 +91,13 @@
 </template>
 
 <script>
+import PasswordTooltip from '@/common/components/PasswordTooltip';
+
 export default {
   name: 'PasswordForm',
+  components: {
+    PasswordTooltip,
+  },
   props: {
     password: {
       type: String,
@@ -149,51 +137,8 @@ export default {
         type: '',
         label: '',
       },
+      isTooltipOpen: false,
     };
-  },
-  computed: {
-    lowBarClassName() {
-      switch (this.passwordStrength.type) {
-        case 'low':
-          return 'bg-red-600';
-        case 'medium':
-          return 'bg-yellow-600';
-        case 'strong':
-          return 'bg-green-600';
-        default:
-          return 'bg-gray-600';
-      }
-    },
-    mediumBarClassName() {
-      switch (this.passwordStrength.type) {
-        case 'medium':
-          return 'bg-yellow-600';
-        case 'strong':
-          return 'bg-green-600';
-        default:
-          return 'bg-gray-600';
-      }
-    },
-    strongBarClassName() {
-      switch (this.passwordStrength.type) {
-        case 'strong':
-          return 'bg-green-600';
-        default:
-          return 'bg-gray-600';
-      }
-    },
-    passwordStrengthLabelClassName() {
-      switch (this.passwordStrength.type) {
-        case 'low':
-          return 'text-red-500';
-        case 'medium':
-          return 'text-yellow-500';
-        case 'strong':
-          return 'text-green-500';
-        default:
-          return '';
-      }
-    },
   },
   watch: {
     password() {
@@ -263,6 +208,16 @@ export default {
       this.isPasswordInputVisible[name] = !this.isPasswordInputVisible[name];
       this.passwordInputType[name] = this.isPasswordInputVisible[name] ? 'text' : 'password';
       this.passwordIconName[name] = this.isPasswordInputVisible[name] ? 'eye-off' : 'eye';
+    },
+    openTooltip() {
+      this.isTooltipOpen = !this.isEmpty(this.$refs.password.value);
+    },
+    closeTooltip() {
+      this.isTooltipOpen = false;
+    },
+    onInput() {
+      this.$emit('password', this.$refs.password.value);
+      this.openTooltip();
     },
   },
 };

--- a/src/components/Settings/Account/PrivacyAndSecuritySection.vue
+++ b/src/components/Settings/Account/PrivacyAndSecuritySection.vue
@@ -104,6 +104,9 @@
               :type="passwordInputType['newPassword']"
               placeholder="Masukkan kata sandi baru"
               class="text-sm placeholder:text-gray-600 p-2 w-full bg-white focus:outline-none"
+              @input="openTooltip"
+              @focus="openTooltip"
+              @blur="closeTooltip"
             >
             <div
               v-show="isPasswordIconVisible['newPassword']"
@@ -117,30 +120,10 @@
             </div>
           </div>
         </div>
-        <!-- Tooltip -->
-        <div
-          v-show="!isEmpty(newPassword)"
-          class="grid grid-cols-2 relative mb-2"
-        >
-          <div class="bg-gray-900 px-3 pt-3 pb-2 rounded-lg text-white text-xs">
-            <div class="grid grid-cols-3 gap-2 mb-2">
-              <div
-                class="h-1 rounded-lg"
-                :class="[lowBarClassName]"
-              />
-              <div
-                class="h-1 rounded-lg"
-                :class="[mediumBarClassName]"
-              />
-              <div
-                class="h-1 rounded-lg"
-                :class="[strongBarClassName]"
-              />
-            </div>
-            <p>Kata sandi Anda <span :class="passwordStrengthLabelClassName">{{ passwordStrength.label }}</span></p>
-          </div>
-          <div class="absolute top-1 left-3 w-3 h-3 -mt-2 rotate-45 bg-gray-900" />
-        </div>
+        <PasswordTooltip
+          :show="isTooltipOpen"
+          :password-strength="passwordStrength"
+        />
         <div class="flex flex-col flex-grow gap-2 mb-4">
           <label
             for="newPasswordConfirmation"
@@ -209,6 +192,7 @@
 import { mapGetters } from 'vuex';
 import BaseButton from '@/common/components/BaseButton';
 import BaseModal from '@/common/components/BaseModal';
+import PasswordTooltip from '@/common/components/PasswordTooltip';
 import { RepositoryFactory } from '@/repositories/RepositoryFactory';
 import { formatDate } from '@/common/helpers/date';
 
@@ -219,6 +203,7 @@ export default {
   components: {
     BaseButton,
     BaseModal,
+    PasswordTooltip,
   },
   data() {
     return {
@@ -226,6 +211,7 @@ export default {
       newPassword: '',
       newPasswordConfirmation: '',
       isPromptOpen: false,
+      isTooltipOpen: false,
       isPasswordInputVisible: {
         currentPassword: false,
         newPassword: false,
@@ -268,48 +254,6 @@ export default {
 
       return !isPasswordEmpty && isPasswordValid;
     },
-    lowBarClassName() {
-      switch (this.passwordStrength.type) {
-        case 'low':
-          return 'bg-red-600';
-        case 'medium':
-          return 'bg-yellow-600';
-        case 'strong':
-          return 'bg-green-600';
-        default:
-          return 'bg-gray-600';
-      }
-    },
-    mediumBarClassName() {
-      switch (this.passwordStrength.type) {
-        case 'medium':
-          return 'bg-yellow-600';
-        case 'strong':
-          return 'bg-green-600';
-        default:
-          return 'bg-gray-600';
-      }
-    },
-    strongBarClassName() {
-      switch (this.passwordStrength.type) {
-        case 'strong':
-          return 'bg-green-600';
-        default:
-          return 'bg-gray-600';
-      }
-    },
-    passwordStrengthLabelClassName() {
-      switch (this.passwordStrength.type) {
-        case 'low':
-          return 'text-red-500';
-        case 'medium':
-          return 'text-yellow-500';
-        case 'strong':
-          return 'text-green-500';
-        default:
-          return '';
-      }
-    },
   },
   watch: {
     currentPassword() {
@@ -324,6 +268,12 @@ export default {
     },
   },
   methods: {
+    openTooltip() {
+      this.isTooltipOpen = !this.isEmpty(this.newPassword);
+    },
+    closeTooltip() {
+      this.isTooltipOpen = false;
+    },
     togglePrompt() {
       this.clearValidationMessage();
       this.clearPasswordInput();


### PR DESCRIPTION
### Changes

- Create `<Tooltip />` component
- Create `<PasswordTooltip />` component based on `<Tooltip />` component
- Improvement on `<PasswordTooltip />` component to follow the acceptance criteria

### Evidence

Title: refactor(password tooltip): move the tooltip into a separate component
Project: Portal Jabar
Participants: @bangunbagustapa 