### PR TITLE
feat: invalid link page

### DIFF
--- a/src/pages/Errors/InvalidRegistrationLink.vue
+++ b/src/pages/Errors/InvalidRegistrationLink.vue
@@ -25,44 +25,43 @@
         </nav>
       </header>
       <main class="h-full -m-20 flex justify-center items-center">
-        <CreateAccountForm />
+        <section
+          class="bg-white rounded-xl flex flex-col w-[576px] h-[317px] items-center justify-center p-8"
+        >
+          <img
+            src="@/assets/icons/mailbox.svg"
+            alt="mail box illustration"
+            width="99"
+            height="81"
+            class="mb-4"
+          >
+          <h1 class="font-lora text-green-700 text-xl text-center font-bold leading-8 mb-2">
+            Link Anda Tidak Valid
+          </h1>
+          <p class="text-blue-gray-800 text-sm leading-6 text-center">
+            Sepertinya link untuk pendaftaran anggota Anda salah atau sudah tidak valid.
+            <br>
+            Untuk informasi lebih lanjut silakan menghubungi <strong>Group Administrator OPD</strong> Anda.
+          </p>
+        </section>
       </main>
     </div>
   </div>
 </template>
 
 <script>
-import { RepositoryFactory } from '@/repositories/RepositoryFactory';
 import HomeIcon from '@/assets/icons/home.svg?inline';
-import CreateAccountForm from '@/components/CreateAccount/Form';
-
-const registrationRepository = RepositoryFactory.get('registration');
 
 export default {
-  name: 'CreateAccount',
+  name: 'InvalidRegistrationLink',
   components: {
     HomeIcon,
-    CreateAccountForm,
-  },
-  async beforeRouteEnter(to, from, next) {
-    const token = to.query?.token || null;
-
-    try {
-      if (!token) {
-        next(`/daftar/error?token=${token}`);
-      } else {
-        await registrationRepository.authorizeInvitationToken(token);
-        next();
-      }
-    } catch (error) {
-      next(`/daftar/error?token=${token}`);
-    }
   },
   data() {
     return {
       portalJabarUrl: process.env.VUE_APP_PORTAL_JABAR_URL,
-      token: this.$route.query.token || null,
     };
   },
+
 };
 </script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -118,6 +118,15 @@ export default [
     },
   },
   {
+    path: '/daftar/error',
+    name: 'Link Tidak Valid',
+    component: () => import('@/pages/Errors/InvalidRegistrationLink'),
+    meta: {
+      public: true,
+      layout: 'AppLayoutPublic',
+    },
+  },
+  {
     path: '*',
     redirect: '/',
   },


### PR DESCRIPTION
#### Overview
- show an error page when the user clicks an invalid invitation link

#### Changes
- add `/daftar/error` route
- create `InvalidRegistrationLink` component
- redirect user to `/daftar/error` route if registration token is invalid

#### Preview
![ezgif-4-093a3803c5](https://user-images.githubusercontent.com/33661143/160535658-a57542ac-6328-48aa-8491-deb6d3c3a1a0.gif)

### Evidence
title: feat invalid link page
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @bangunbagustapa @naufalihsank 

