### PR TITLE
feat: permissions

### DIFF
--- a/src/common/components/Restricted.vue
+++ b/src/common/components/Restricted.vue
@@ -8,7 +8,7 @@
 import { mapGetters } from 'vuex';
 
 export default {
-  name: 'Resctricted',
+  name: 'Restricted',
   props: {
     permission: {
       type: String,

--- a/src/common/components/Restricted.vue
+++ b/src/common/components/Restricted.vue
@@ -1,0 +1,29 @@
+<template>
+  <div v-if="isPermitted">
+    <slot />
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'Resctricted',
+  props: {
+    permission: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    ...mapGetters('auth', ['permissions']),
+    isPermitted() {
+      if (Array.isArray(this.permissions) && this.permissions.length) {
+        return this.permissions.includes(this.permission);
+      }
+      return false;
+    },
+  },
+
+};
+</script>

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -4,28 +4,80 @@ import { rest } from 'msw';
 const BASE_URL = process.env.VUE_APP_API_URL;
 
 const handlers = [
-  rest.post(`${BASE_URL}/v1/auth/login`, (req, res, ctx) => res(
-    ctx.status(401),
-  )),
-
   // rest.post(`${BASE_URL}/v1/auth/login`, (req, res, ctx) => res(
-  //   ctx.status(200),
+  //   ctx.status(401),
   //   ctx.json({
-  //     access_token: 'asdasdasd',
-  //     refresh_token: '123123123',
-  //     exp: '123123',
+  //     message: 'Invalid credentials',
   //   }),
   // )),
 
-  // rest.get(`${BASE_URL}/v1/auth/me`, (req, res, ctx) => res(
-  //   ctx.status(200),
+  rest.post(`${BASE_URL}/v1/auth/login`, (req, res, ctx) => res(
+    ctx.status(200),
+    ctx.json({
+      access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+      refresh_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+      exp: 1649047862,
+    }),
+  )),
+
+  // rest.get(`${BASE_URL}/v1/users/me`, (req, res, ctx) => res(
+  //   ctx.status(500),
+  // )),
+
+  rest.get(`${BASE_URL}/v1/users/me`, (req, res, ctx) => res(
+    ctx.status(200),
+    ctx.json({
+      data: {
+        id: 'b5a35743-2d4b-4559-939a-2ba21c06f39c',
+        name: 'Mock User',
+        username: 'mockuser',
+        email: 'mock@user.com',
+        nip: '123456789012345672',
+        occupation: 'Kepala Dinas',
+        photo: 'https://media.newyorker.com/photos/5f01e383b975762d612e0ff3/2:2/w_746,h_746,c_limit/Barasch-Avatar.jpg',
+        unit: {
+          id: 26,
+          name: 'Dinas Komunikasi dan Informatika',
+        },
+        role: {
+          id: 2,
+          name: 'Group Admin',
+        },
+        last_password_changed: null,
+      },
+    }),
+  )),
+
+  // rest.get(`${BASE_URL}/v1/auth/permissions`, (req, res, ctx) => res(
+  //   ctx.status(500),
   //   ctx.json({
   //     data: {
-  //       id: '121212',
-  //       username: 'bangun',
+  //       message: 'Invalid credentials',
   //     },
   //   }),
   // )),
+
+  rest.get(`${BASE_URL}/v1/auth/permissions`, (req, res, ctx) => res(
+    ctx.status(200),
+    ctx.json({
+      data: {
+        permissions: [
+          'event.manage',
+          'news.archive',
+          'news.manage',
+          'news.publish',
+          'user.cancel-invitation',
+          'user.change-email',
+          'user.deactivate',
+          'user.invite',
+          'user.manage',
+          'user.request-to-be-admin',
+          'user.set-as-admin',
+        ],
+      },
+    }),
+  )),
+
 ];
 
 export { handlers };

--- a/src/repositories/authRepository.js
+++ b/src/repositories/authRepository.js
@@ -19,4 +19,11 @@ export default {
   refreshToken(payload) {
     return Repository.post(`${resource}/refresh`, payload);
   },
+  /**
+   * Get user permissions
+   * @returns {Promise}
+   */
+  getPermissions() {
+    return Repository.get(`${resource}/permissions`);
+  },
 };


### PR DESCRIPTION
#### Related
- [S41A3 - Kontributor](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/recifJxpXxqujZywU?blocks=hide)
- [S41A2 - Administrator](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/recnggRF6R157aPXc?blocks=hide)
- [S41A1 - Group Admin](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/recf5r1jTKYaBFJej?blocks=hide)

#### Changes
- add `permissions` state on `store/auth`
- get permissions data after login
- add `Restricted` component
- improve mock response for `/users/me` and `/auth/permissions`

### Evidence
title: feat permission
project: Portal Jabar
participants: @Ibwedagama @bangunbagustapa 