### PR TITLE
fix: state cache on settings page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,9 @@
 <template>
   <div id="app">
     <AppLayout>
-      <router-view />
+      <keep-alive include="Settings">
+        <router-view />
+      </keep-alive>
     </AppLayout>
     <portal-target name="modal" />
     <Toast />

--- a/src/components/Settings/Member/ListSection/index.vue
+++ b/src/components/Settings/Member/ListSection/index.vue
@@ -59,7 +59,7 @@ export default {
       return [];
     },
   },
-  mounted() {
+  activated() {
     this.fetchMembers();
   },
   methods: {


### PR DESCRIPTION
### Related
- [S35A2 - View Detail Akun Anggota](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/reciLujaYRdamR4Ln?blocks=hide)

### Issues
Actual Result:
Jika klik tombol kembali, saat ini masih menampilkan halaman akun

Steps to reproduce:
- akses view list akun anggota
- klik aksi pada salah satu anggota
- klik lihat detail
- menampilkan halaman detail anggota
- klik tombol kembali

Expected Result:
Jika tombol kembali di klik maka akan kembali ke halaman view list akun anggota

### Changes
- add `keep-alive` component to cache `router-view` but only for `Settings` page
- change `mounted()` hook to `activated()` hook to ensure data fetching is always run every time the user loads the settings page

### Preview
https://user-images.githubusercontent.com/33661143/161892634-9ccd55df-8630-41fd-845b-c2d2b235503a.mov

### Evidence
title: fix state cache on settings page
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @bangunbagustapa 
