### PR TITLE
fix: create-account-form on small screen

### DIFF
--- a/src/components/CreateAccount/Form/index.vue
+++ b/src/components/CreateAccount/Form/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="!isAccountCreated"
-    class="bg-white w-[443px] p-8 rounded-lg flex flex-col gap-6"
+    class="p-5 mt-10 bg-white w-[443px] rounded-lg flex flex-col gap-6 xl:p-8 xl:mt-0 "
   >
     <!-- Title -->
     <div class="flex flex-col gap-3">
@@ -55,27 +55,37 @@
         </div>
       </li>
     </ul>
+
     <!-- Step 1 -->
-    <DetailInformationForm
+    <div
       v-show="firstStep"
-      :name="name"
-      :occupation="occupation"
-      :nip="nip"
-      :errors="errors"
-      @name="name = $event"
-      @occupation="occupation = $event"
-      @nip="nip = $event"
-    />
+      class="max-h-[200px] pr-4 overflow-y-auto xl:max-h-full"
+    >
+      <DetailInformationForm
+        :name="name"
+        :occupation="occupation"
+        :nip="nip"
+        :errors="errors"
+        @name="name = $event"
+        @occupation="occupation = $event"
+        @nip="nip = $event"
+      />
+    </div>
     <!-- Step 2 -->
-    <PasswordForm
+    <div
       v-show="lastStep"
-      :password="password"
-      :password-confirmation="passwordConfirmation"
-      :errors="errors"
-      @password-strength="passwordStrength = $event"
-      @password="password = $event"
-      @password-confirmation="passwordConfirmation = $event"
-    />
+      ref="lastStepContainer"
+      class="max-h-[200px] pr-4 overflow-y-auto xl:max-h-full"
+    >
+      <PasswordForm
+        :password="password"
+        :password-confirmation="passwordConfirmation"
+        :errors="errors"
+        @password-strength="passwordStrength = $event"
+        @password="password = $event"
+        @password-confirmation="passwordConfirmation = $event"
+      />
+    </div>
     <!-- Action button -->
     <div class="flex gap-5">
       <BaseButton
@@ -184,6 +194,9 @@ export default {
       if (this.passwordConfirmation === '') this.setErrors('passwordConfirmation', 'Kata sandi harus diisi');
       else if (this.password !== this.passwordConfirmation) this.setErrors('passwordConfirmation', 'Kata sandi tidak sama');
       else this.clearErrors('passwordConfirmation');
+    },
+    lastStep() {
+      this.$refs.lastStepContainer.scrollIntoView({ behavior: 'smooth' });
     },
   },
   created() {


### PR DESCRIPTION
#### Overview
- as described by the title

#### Changes
- refactor `CreateAccountForm` component
- adjust styling on smaller screen

#### Preview
_tested on 800 x 600 screen resolution_

**Before**
![Screen Shot 2022-04-06 at 13 09 32](https://user-images.githubusercontent.com/33661143/161907771-e9b0c697-c3a7-4083-8fdd-24faaf5f8088.png)

**After**
![Screen Shot 2022-04-06 at 13 09 04](https://user-images.githubusercontent.com/33661143/161907790-63eab81a-b1d2-44b1-ad99-1f7b6f9d1ed8.png)

### Evidence
title: fix create-account-form styling on small screen
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @adzharamrullah @bangunbagustapa @yoslie 
