### PR TITLE
improve: news preview download

### DIFF
--- a/src/components/NewsInformation/News/NewsPreview.vue
+++ b/src/components/NewsInformation/News/NewsPreview.vue
@@ -510,7 +510,13 @@ export default {
   },
   computed: {
     headerImage() {
-      return this.news?.image || null;
+      /**
+       * NOTE:
+       * Add random query string on image source to prevent browser cache.
+       * This will ensure the image is rendered when the user downloads the PDF
+       */
+      const randomStr = new Date().getTime();
+      return this.news?.image ? `${this.news?.image}?${randomStr}` : null;
     },
     title() {
       return this.news?.title || '';
@@ -553,9 +559,24 @@ export default {
       }).format(number);
     },
     downloadPDF() {
+      /**
+       * NOTE:
+       * Add random query string on image source to prevent browser cache.
+       * This will ensure the image is rendered when the user downloads the PDF
+       */
+      const images = document.querySelectorAll('.article__body img');
+
+      if (images.length) {
+        images.forEach((image, index) => {
+          const randomStr = new Date().getTime() + index;
+          image.src += `?${randomStr}`;
+        });
+      }
+
       html2canvas(this.$refs.content, {
         windowWidth: 1440, // render content on 1440px width
         useCORS: true,
+        allowTaint: true,
       })
         .then((canvas) => {
           const pageWidth = 210; // Standard A4 paper width (mm)

--- a/src/components/NewsInformation/News/NewsPreview.vue
+++ b/src/components/NewsInformation/News/NewsPreview.vue
@@ -576,7 +576,6 @@ export default {
       html2canvas(this.$refs.content, {
         windowWidth: 1440, // render content on 1440px width
         useCORS: true,
-        allowTaint: true,
       })
         .then((canvas) => {
           const pageWidth = 210; // Standard A4 paper width (mm)


### PR DESCRIPTION
#### Overview
`html2canvas` throws a CORS error when it tries to render an image from an external source (AWS S3 Bucket or Cloudfront). This happened because `html2canvas` tried to render images that has been cached by the browser. To fix this issue we can simply add a random query string to all the images to prevent the browser from caching them.

ref: https://stackoverflow.com/questions/42263223/how-do-i-handle-cors-with-html2canvas-and-aws-s3-images

#### Changes
- add a random query string on `headerImage` computed property
- add a random query string on all images when the user downloads the PDF

#### Preview
![ezgif-1-6f0caadc1f](https://user-images.githubusercontent.com/33661143/163112747-7b2cd591-12bd-458b-84db-1ec17e3e758e.gif)


### Evidence
title: improve news preview download
participants: @Ibwedagama @bangunbagustapa @khihadysucahyo @naufalihsank 
