### PR TITLE
hotfix: error save as draft when technical value is empty

### DIFF
--- a/src/store/modules/public-service/masterDataForm.js
+++ b/src/store/modules/public-service/masterDataForm.js
@@ -671,32 +671,44 @@ export default {
       }
     },
     generateFormData({ state }, status) {
-      let stepOnefacilities;
-      let stepTwoState;
       const { technical } = state.stepOne.services.information;
       const applicationStatus = state.stepTwo.application.status;
 
+      const defaultApplicationState = getDefaultState().stepTwo.application;
+      const defaultFacilityState = getDefaultState().stepOne.services.information.facilities;
+
+      let stepOneFacilities;
+      let stepTwoState;
+
       // generate different state based on step one state (technical)
       if (technical === 'ONLINE') {
-        stepOnefacilities = getDefaultState().stepOne.services.information.facilities;
-        stepTwoState = {
-          ...state.stepTwo.application,
-        };
-      } else {
-        stepOnefacilities = state.stepOne.services.information.facilities;
-        stepTwoState = {
-          ...getDefaultState().stepTwo.application,
-        };
+        stepOneFacilities = { ...defaultFacilityState };
+        stepTwoState = { ...state.stepTwo };
       }
 
       // generate different state based on step two state (status)
-      if (applicationStatus === 'NOT-AVAILABLE') {
+      if (technical === 'ONLINE' && applicationStatus === 'NOT-AVAILABLE') {
+        stepOneFacilities = { ...defaultFacilityState };
         stepTwoState = {
-          ...getDefaultState().stepTwo.application,
-          status: 'NOT-AVAILABLE',
+          application: {
+            ...defaultApplicationState,
+            status: 'NOT-AVAILABLE',
+          },
         };
-      } else {
-        stepTwoState = { ...state.stepTwo.application };
+      }
+
+      if (technical === 'OFFLINE') {
+        stepOneFacilities = { ...state.stepOne.services.information.facilities };
+        stepTwoState = {
+          application: {
+            ...defaultApplicationState,
+          },
+        };
+      }
+
+      if (!technical) {
+        stepOneFacilities = { ...state.stepOne.services.information.facilities };
+        stepTwoState = { ...state.stepTwo };
       }
 
       const formData = {
@@ -717,11 +729,11 @@ export default {
           },
           information: {
             ...state.stepOne.services.information,
-            facilities: { ...stepOnefacilities },
+            facilities: { ...stepOneFacilities },
           },
           location: [...state.stepOne.services.location],
         },
-        application: { ...stepTwoState },
+        application: { ...stepTwoState.application },
         additional_information: { ...state.stepThree.additional_information },
         status,
       };


### PR DESCRIPTION
### Issues
- [T306 [PROD] - [Create Master Data Layanan] Gagal create layanan](https://app.clickup.com/t/860qyfeg6)

### Overview
Failed to save the form as a draft because `technical` value is null or empty causing `application` object to be undefined

### Evidence
title: hotfix error save as draft when technical value is empty
project: Portal Jabar
participants: @Ibwedagama @doohanas 