### PR TITLE
update: fix change logo to trigger save button in edit form quick link

### DIFF
--- a/src/pages/LandingPage/CreateEditAccessLink.vue
+++ b/src/pages/LandingPage/CreateEditAccessLink.vue
@@ -15,7 +15,7 @@
               type="submit"
               class="bg-green-700 hover:bg-green-600 font-lato text-sm text-white"
               data-cy="access-link-form__save-button"
-              :disabled="invalid || (!changed && !isToggled)"
+              :disabled="invalid || (!changed && !isToggled && !isLogoChanged)"
               @click="onConfirmation"
             >
               <p>
@@ -239,6 +239,7 @@
           <BaseButton
             class="bg-green-700 hover:bg-green-600 text-sm text-white"
             data-cy="access-link-modal__button-save"
+            :disabled="isDisableSaveLogo"
             @click="onSaveLogo"
           >
             Simpan Logo
@@ -380,6 +381,7 @@ export default {
         page: 1,
       },
       selectedLogo: '',
+      isLogoChanged: false,
       form: {
         image: '',
         title: '',
@@ -425,6 +427,9 @@ export default {
     },
     messageIconClassName() {
       return this.submitStatus === 'SUCCESS' ? 'text-green-600' : 'text-red-600';
+    },
+    isDisableSaveLogo() {
+      return !(this.selectedLogo);
     },
   },
   async mounted() {
@@ -486,6 +491,9 @@ export default {
     onSaveLogo() {
       this.showListLogo = false;
       this.form.image = this.selectedLogo;
+      if (this.isEditMode) {
+        this.isLogoChanged = true;
+      }
     },
     onConfirmation() {
       this.submitStatus = FORM_SUBMIT_STATUS.CONFIRMATION;


### PR DESCRIPTION
## Changes
- fix disabled enabled save form data not work on change logo in edit form quick link
- disabled button save logo in popup list when no logo selected

## Evidence
title: fix disabled enabled save button not work on change logo in edit form quick link
project: Portal Jabar
participants: @yoslie @naufalihsank @marsellavaleria19 @doohanas 